### PR TITLE
Allow swap to toggle whether trades can happen or not.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "ed25519"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3974,6 +3980,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "arrayref",
+ "dyn-clone",
  "enum_dispatch",
  "num-derive",
  "num-traits",

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -14,6 +14,7 @@ fuzz = ["arbitrary"]
 
 [dependencies]
 arrayref = "0.3.6"
+dyn-clone = "1.0.4"
 enum_dispatch = "0.3.4"
 num-derive = "0.3"
 num-traits = "0.2"

--- a/token-swap/program/src/curve/base.rs
+++ b/token-swap/program/src/curve/base.rs
@@ -50,7 +50,7 @@ pub struct SwapResult {
 
 /// Concrete struct to wrap around the trait object which performs calculation.
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SwapCurve {
     /// The type of curve contained in the calculator, helpful for outside
     /// queries

--- a/token-swap/program/src/curve/calculator.rs
+++ b/token-swap/program/src/curve/calculator.rs
@@ -1,5 +1,5 @@
 //! Swap calculations
-
+use dyn_clone::{clone_trait_object, DynClone};
 use {crate::error::SwapError, spl_math::precise_number::PreciseNumber, std::fmt::Debug};
 
 /// Initial amount of pool tokens for swap contract, hard-coded to something
@@ -79,8 +79,10 @@ pub trait DynPack {
     fn pack_into_slice(&self, dst: &mut [u8]);
 }
 
+clone_trait_object!(CurveCalculator);
+
 /// Trait representing operations required on a swap curve
-pub trait CurveCalculator: Debug + DynPack {
+pub trait CurveCalculator: Debug + DynPack + DynClone {
     /// Calculate how much destination token will be provided given an amount
     /// of source token.
     fn swap_without_fees(

--- a/token-swap/program/src/error.rs
+++ b/token-swap/program/src/error.rs
@@ -91,6 +91,9 @@ pub enum SwapError {
     /// The operation cannot be performed on the given curve
     #[error("The operation cannot be performed on the given curve")]
     UnsupportedCurveOperation,
+    /// The swap is closed for trading
+    #[error("The swap is closed for trading")]
+    SwapClosed,
 }
 impl From<SwapError> for ProgramError {
     fn from(e: SwapError) -> Self {

--- a/token-swap/program/src/instruction.rs
+++ b/token-swap/program/src/instruction.rs
@@ -275,7 +275,7 @@ impl SwapInstruction {
                 })
             }
             6 => {
-                let (&is_trading, _rest) = rest.split_first().ok_or(SwapError::InvalidInstruction)?;
+                let (&is_trading, rest) = rest.split_first().ok_or(SwapError::InvalidInstruction)?;
                 if rest.len() >= Fees::LEN {
                     let (fees, rest) = rest.split_at(Fees::LEN);
                     let fees = Fees::unpack_unchecked(fees)?;

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -11,6 +11,7 @@ use crate::{
     instruction::{
         DepositAllTokenTypes, DepositSingleTokenTypeExactAmountIn, Initialize, Swap,
         SwapInstruction, WithdrawAllTokenTypes, WithdrawSingleTokenTypeExactAmountOut,
+        ToggleSwap
     },
     state::{SwapState, SwapV1, SwapVersion},
 };
@@ -220,6 +221,7 @@ impl Processor {
         let fee_account_info = next_account_info(account_info_iter)?;
         let destination_info = next_account_info(account_info_iter)?;
         let token_program_info = next_account_info(account_info_iter)?;
+        let trading_authority = next_account_info(account_info_iter)?;
 
         let token_program_id = *token_program_info.key;
         if SwapVersion::is_initialized(&swap_info.data.borrow()) {
@@ -317,6 +319,8 @@ impl Processor {
             pool_fee_account: *fee_account_info.key,
             fees,
             swap_curve,
+            is_trading: true,
+            trading_authority: *trading_authority.key,
         });
         SwapVersion::pack(obj, &mut swap_info.data.borrow_mut())?;
         Ok(())
@@ -377,6 +381,9 @@ impl Processor {
         }
         if *token_program_info.key != *token_swap.token_program_id() {
             return Err(SwapError::IncorrectTokenProgramId.into());
+        }
+        if !token_swap.is_trading() {
+            return Err(SwapError::SwapClosed.into());
         }
 
         let source_account =
@@ -992,6 +999,45 @@ impl Processor {
         Ok(())
     }
 
+    pub fn process_toggle_swap(
+        is_trading: bool,
+        accounts: &[AccountInfo],
+    ) -> ProgramResult {
+        let account_info_iter = &mut accounts.iter();
+        let swap_info = next_account_info(account_info_iter)?;
+        let trading_authority = next_account_info(account_info_iter)?;
+
+        if !trading_authority.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        let token_swap = SwapVersion::unpack(&swap_info.data.borrow())?;
+
+        if trading_authority.key != token_swap.trading_authority() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        let obj = SwapVersion::SwapV1(SwapV1 {
+            is_initialized: token_swap.is_initialized(),
+            nonce: token_swap.nonce(),
+            token_program_id: *token_swap.token_program_id(),
+            token_a: *token_swap.token_a_account(),
+            token_b: *token_swap.token_b_account(),
+            pool_mint: *token_swap.pool_mint(),
+            token_a_mint: *token_swap.token_a_mint(),
+            token_b_mint: *token_swap.token_b_mint(),
+            pool_fee_account: *token_swap.pool_fee_account(),
+            fees: *token_swap.fees(),
+            swap_curve: *token_swap.swap_curve(),
+            is_trading: is_trading,
+            trading_authority: *token_swap.trading_authority(),
+        });
+
+        SwapVersion::pack(obj, &mut swap_info.data.borrow_mut())?;
+
+        Ok(())
+    }
+
     /// Processes an [Instruction](enum.Instruction.html).
     pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
         Self::process_with_constraints(program_id, accounts, input, &SWAP_CONSTRAINTS)
@@ -1083,6 +1129,12 @@ impl Processor {
                     maximum_pool_token_amount,
                     accounts,
                 )
+            }
+            SwapInstruction::ToggleSwap(ToggleSwap {
+                is_trading,
+            }) => {
+                msg!("Instruction: ToggleSwap");
+                Self::process_toggle_swap(is_trading, accounts)
             }
         }
     }

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -1002,8 +1002,6 @@ impl Processor {
     /// Processes a [ToggleSwap](enum.Instruction.html).
     pub fn process_toggle_swap(
         is_trading: bool,
-        fees: Fees,
-        swap_curve: SwapCurve,
         accounts: &[AccountInfo],
     ) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
@@ -1020,10 +1018,6 @@ impl Processor {
             return Err(ProgramError::InvalidAccountData);
         }
 
-        if *token_swap.fees() != fees || *token_swap.swap_curve() != swap_curve {
-            return Err(SwapError::IncorrectSwapAccount.into());
-        }
-
         let obj = SwapVersion::SwapV1(SwapV1 {
             is_initialized: token_swap.is_initialized(),
             nonce: token_swap.nonce(),
@@ -1034,8 +1028,8 @@ impl Processor {
             token_a_mint: *token_swap.token_a_mint(),
             token_b_mint: *token_swap.token_b_mint(),
             pool_fee_account: *token_swap.pool_fee_account(),
-            fees,
-            swap_curve,
+            fees: token_swap.fees().clone(),
+            swap_curve: token_swap.swap_curve().clone(),
             is_trading: is_trading,
             trading_authority: *token_swap.trading_authority(),
         });
@@ -1139,11 +1133,9 @@ impl Processor {
             }
             SwapInstruction::ToggleSwap(ToggleSwap {
                 is_trading,
-                fees,
-                swap_curve
             }) => {
                 msg!("Instruction: ToggleSwap");
-                Self::process_toggle_swap(is_trading, fees, swap_curve, accounts)
+                Self::process_toggle_swap(is_trading, accounts)
             }
         }
     }


### PR DESCRIPTION
Allow an authority to toggle whether a swap can or cannot trade. This allows us to disable trading e.g. when a market is resolved.